### PR TITLE
Add safety to invalid audio tracks

### DIFF
--- a/src/ts/audio/AudioPlayer.ts
+++ b/src/ts/audio/AudioPlayer.ts
@@ -56,7 +56,7 @@ class AudioPlayer implements IAudioPlayer {
 		useSecondaryStorage: boolean
 	): Promise<void> {
 		if (options.src == null) {
-			console.log("given source is null, skipping");
+			Logger.logDebug("Source is null, skipping");
 			return;
 		}
 

--- a/src/ts/audio/AudioPlayer.ts
+++ b/src/ts/audio/AudioPlayer.ts
@@ -68,7 +68,7 @@ class AudioPlayer implements IAudioPlayer {
 		await chosenStorage.storeAudio({
 			src: options.src,
 			audioTimings: options.audioTimings,
-			loop: this._$loopButton.is(":checked"),
+			loop: !useSecondaryStorage && this._$loopButton.is(":checked"),
 			volume: options.volume
 		});
 		this._isAwaitingAudio = false;

--- a/src/ts/audio/AudioSource.ts
+++ b/src/ts/audio/AudioSource.ts
@@ -62,7 +62,7 @@ class AudioSource extends EventTarget implements IAudioController {
 		this._audio = new Audio();
 		this._audio.preload = "metadata";
 		this._audio.autoplay = autoPlay ?? true;
-		this.loop = options.loop ?? false;
+		this.loop = options?.loop ?? false;
 
 		this._audio.disableRemotePlayback = true;
 

--- a/src/ts/audio/AudioSource.ts
+++ b/src/ts/audio/AudioSource.ts
@@ -28,7 +28,7 @@ class AudioSource extends EventTarget implements IAudioController {
 	}
 
 	public set loop(loop: boolean) {
-		if (!this._preserve) {
+		if (loop && !this._preserve) {
 			throw new ReferenceError("Can't loop audio if 'preserve' is not enabled");
 		}
 
@@ -62,7 +62,7 @@ class AudioSource extends EventTarget implements IAudioController {
 		this._audio = new Audio();
 		this._audio.preload = "metadata";
 		this._audio.autoplay = autoPlay ?? true;
-		this._audio.loop = false;
+		this.loop = options.loop ?? false;
 
 		this._audio.disableRemotePlayback = true;
 

--- a/src/ts/audio/AudioSource.ts
+++ b/src/ts/audio/AudioSource.ts
@@ -11,6 +11,8 @@ class AudioSource extends EventTarget implements IAudioController {
 	 */
 	private _preserve: boolean;
 
+	private _canPlayCurrentSource: CanPlayTypeResult = "maybe";
+
 	private _destroyed: boolean = false;
 
 	/**
@@ -215,8 +217,6 @@ class AudioSource extends EventTarget implements IAudioController {
 				this.triggerEvent("pause");
 			})
 			.on("canplay", () => {
-				// TODO: sear
-
 				Logger.logDebug("Audio source can play");
 
 				this.triggerEvent("canplay");


### PR DESCRIPTION
Basic but functional implementation. This should prevent unhandled errors from firing after clicking an invalid audio element. I also should probably prevent some files to be dropped in the first place, but I'm not sure.

This also fixes an oversight with the loop option.
Closes #8