### PR TITLE
Improve and fix checks to splice last logger argument for manual typing

### DIFF
--- a/src/ts/utility/Logger.ts
+++ b/src/ts/utility/Logger.ts
@@ -63,11 +63,15 @@ abstract class Logger {
 		let manualCallerClass, manualCallerFunction;
 
 		let lastArg = args.slice(-1)?.[0];
+		let lastArgKeys = Object.keys(lastArg ?? {});
+
+		// Check for the expected structure
 		if (
 			lastArg != undefined &&
 			typeof lastArg === "object" &&
-			Object.keys(lastArg).length <= 2 &&
-			Object.keys(lastArg).every((key) => key == "class" || key == "function")
+			lastArgKeys.length > 0 &&
+			lastArgKeys.length <= 2 &&
+			lastArgKeys.every((key) => key == "class" || key == "function")
 		) {
 			args.splice(-1);
 


### PR DESCRIPTION
It always bothered me that some prints lacked data given at the end.

See this "Navigator" example at the end of the log:
![image](https://github.com/Gabixel/Soundboard/assets/43073074/fe9cebf9-d0c3-49b4-a497-88461af93735)

Now looks correct:
![image](https://github.com/Gabixel/Soundboard/assets/43073074/bc1be003-ed7d-4139-9ea1-27ef1768d5e0)

It was falsely interpreted as manual typing. Now it's fixed