### PR TITLE
Add VSCode extensions recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": ["mrcrowl.easy-less"]
+}


### PR DESCRIPTION
Only recommending "Easy Less" (as written in the README), for now