### PR TITLE
Fix files drop event opening a new window

### DIFF
--- a/src/ts/grid/events/GridEvents.ts
+++ b/src/ts/grid/events/GridEvents.ts
@@ -196,12 +196,12 @@ class GridEvents extends EventTarget {
 
 				if (notSuccesful) return;
 
+				e.preventDefault();
+				e.stopPropagation();
+
 				let $button = getTarget(e);
 
 				$button.trigger("dragleave");
-
-				e.preventDefault();
-				e.stopPropagation();
 
 				$button.removeClass("file-dragover");
 

--- a/src/ts/start/Main.ts
+++ b/src/ts/start/Main.ts
@@ -48,6 +48,11 @@ abstract class Main {
 		} else {
 			throw new TypeError("JQueryFixes is not available");
 		}
+		
+		// This prevents a new window from opening when a file is randomly dropped on the page
+		$(document).on("drop", (e) => {
+			e.preventDefault();
+		});
 
 		if (appPathRequest) {
 			await appPathRequest;

--- a/src/ts/start/MainWindow.ts
+++ b/src/ts/start/MainWindow.ts
@@ -120,7 +120,7 @@ abstract class MainWindow extends Main {
 			e.preventDefault();
 			SoundboardApi.mainWindow.openContextMenu();
 		});
-		
+
 		$(document).on("keydown", (e) => {
 			if (e.ctrlKey && e.key == "Tab") {
 				let ev = "tabchange" + (e.shiftKey ? "prev" : "next");
@@ -137,11 +137,6 @@ abstract class MainWindow extends Main {
 				$(document).trigger(eventName);
 				return false;
 			}
-		});
-
-		// This prevents a new window from opening when a file is randomly dropped on the page
-		$(document).on("drop", (e) => {
-			e.preventDefault();
 		});
 	}
 

--- a/src/ts/start/MainWindow.ts
+++ b/src/ts/start/MainWindow.ts
@@ -116,10 +116,11 @@ abstract class MainWindow extends Main {
 
 		// Setup context menu
 		// TODO: class?
-		$(document).on("contextmenu", () => {
+		$(document).on("contextmenu", (e) => {
+			e.preventDefault();
 			SoundboardApi.mainWindow.openContextMenu();
 		});
-
+		
 		$(document).on("keydown", (e) => {
 			if (e.ctrlKey && e.key == "Tab") {
 				let ev = "tabchange" + (e.shiftKey ? "prev" : "next");
@@ -136,6 +137,11 @@ abstract class MainWindow extends Main {
 				$(document).trigger(eventName);
 				return false;
 			}
+		});
+
+		// This prevents a new window from opening when a file is randomly dropped on the page
+		$(document).on("drop", (e) => {
+			e.preventDefault();
 		});
 	}
 


### PR DESCRIPTION
Fixes #39.

Started to happen recently, and was very annoying sometimes.
Noticed the missing `preventDefault()` for this event thanks to [this comment](https://github.com/electron/electron/issues/39839#issuecomment-1749969317).

Should be a straightforward fix, but I think we need a more amicable root logic if more events must be prevented by default.